### PR TITLE
fix: add required iam permissions for provisioning

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -37,6 +37,18 @@ data "aws_iam_policy_document" "efs_csi_driver" {
       values   = ["true"]
     }
   }
+
+  statement {
+    actions = [
+      "elasticfilesystem:TagResource"
+    ]
+    resources = ["*"]
+    effect    = "Allow"
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
+      values   = ["true"]
+    }
 }
 
 resource "aws_iam_policy" "efs_csi_driver" {


### PR DESCRIPTION
- EFS dynamic provisioning now requires tag permissions
- See: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/iam-policy-example.json#L26
- EFS volume needed for docker build cache for jenkins workloads on k8s

Ref: REL-1539