### PR TITLE
fix: Add missing brace

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -49,6 +49,7 @@ data "aws_iam_policy_document" "efs_csi_driver" {
       variable = "aws:ResourceTag/efs.csi.aws.com/cluster"
       values   = ["true"]
     }
+  }
 }
 
 resource "aws_iam_policy" "efs_csi_driver" {


### PR DESCRIPTION
Add the missing `}` to the new TagResource block.